### PR TITLE
[버그수정] 덕담 조회, 추가 API 에러 수정

### DIFF
--- a/pages/api/duckdam/[id].ts
+++ b/pages/api/duckdam/[id].ts
@@ -1,24 +1,17 @@
-import { collection, doc, getDoc } from "@firebase/firestore";
+import { collection, doc, getDoc } from '@firebase/firestore';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { db } from 'utils/firebase';
-
-type ValueType = {
-    img_url: string;
-    first_word: string;
-    second_word: string;
-    third_word: string;
-};
-type DataType = Record<string, ValueType>;
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (req.method === 'GET') {
         const { id } = req.query;
         const parseId = id as string;
 
-        const docRef = doc(db, "duckdam", parseId);
+        const docRef = doc(db, 'duckdam', parseId);
         const docSnap = await getDoc(docRef);
-        
-        res.status(200).json(docSnap.data());
+
+        if (docSnap.data()) res.status(200).json(docSnap.data());
+        else res.status(502).json('Bad Request');
     }
 }
 

--- a/pages/api/duckdam/[id].ts
+++ b/pages/api/duckdam/[id].ts
@@ -1,4 +1,4 @@
-import { collection, getDocs } from '@firebase/firestore';
+import { collection, doc, getDoc } from "@firebase/firestore";
 import { NextApiRequest, NextApiResponse } from 'next';
 import { db } from 'utils/firebase';
 
@@ -12,14 +12,13 @@ type DataType = Record<string, ValueType>;
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (req.method === 'GET') {
-        const data: DataType = {};
-        const querySnapshot = await getDocs(collection(db, 'duckdam'));
-        querySnapshot.forEach((doc) => {
-            const value = doc.data() as ValueType;
-            data[doc.id] = value;
-        });
+        const { id } = req.query;
+        const parseId = id as string;
 
-        res.status(200).json(data);
+        const docRef = doc(db, "duckdam", parseId);
+        const docSnap = await getDoc(docRef);
+        
+        res.status(200).json(docSnap.data());
     }
 }
 

--- a/pages/api/duckdam/add.ts
+++ b/pages/api/duckdam/add.ts
@@ -2,13 +2,6 @@ import { addDoc, collection } from '@firebase/firestore';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { db } from 'utils/firebase';
 
-type ValueType = {
-    img_url: string;
-    first_word: string;
-    second_word: string;
-    third_word: string;
-};
-
 async function handler(req: NextApiRequest, res: NextApiResponse) {
     if (req.method === 'POST') {
         const { img_url, first_word, second_word, third_word } = req.body;
@@ -19,7 +12,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
             second_word: second_word,
             third_word: third_word,
         });
-        res.status(200).json('success');
+        res.status(200).json(docRef.id);
     }
 }
 

--- a/pages/api/duckdam/add.ts
+++ b/pages/api/duckdam/add.ts
@@ -1,6 +1,5 @@
 import { addDoc, collection } from '@firebase/firestore';
 import { NextApiRequest, NextApiResponse } from 'next';
-// eslint-disable-next-line import/no-unresolved
 import { db } from 'utils/firebase';
 
 type ValueType = {


### PR DESCRIPTION
## 작업 내용
- 덕담 단 건으로 조회되도록 API 변경
- 덕담 추가 시 해당 문서의 id 값이 반환되도록 변경

## 관련 이슈
#8 
API 부분 설명 및 파라미터 수정하였습니다.

## 참고 자료 (option)
https://firebase.google.com/docs/firestore/manage-data/add-data