### PR TITLE
[버그수정] 메타태그 og:image 매핑 오류 수정

### DIFF
--- a/components/common/MetaHead.tsx
+++ b/components/common/MetaHead.tsx
@@ -33,10 +33,10 @@ const MetaHead = ({
             />
             <meta property="og:title" content={title} />
             <meta property="og:description" content={description} />
-            {/* twitter Og */}
+            {/* twitter og */}
             <meta name="twitter:title" content={title} />
             <meta name="twitter:image" content={img_url} />
-            <meta name="twitter:card" content="summary" />
+            <meta name="twitter:card" content={description} />
             <meta name="twitter:creator" content={'@duckdam trio'} />
             <meta name="twitter:site" content={'@duckdam trio'} />/
             <meta name="twitter:description" content={description} />

--- a/components/common/MetaHead.tsx
+++ b/components/common/MetaHead.tsx
@@ -12,13 +12,17 @@ const MetaHead = ({
     tabTitle = '여기 덕담이요!',
     title = '여기 덕담이요!',
     description = '가족, 친구들에게 따뜻한 한마디를 선물해보세요!',
-    img_url = process.env.NEXT_PUBLIC_DEFAULT_OG_IMAGE,
+    img_url,
 }: OptionalMetaHeadProps) => {
+    if (!img_url) {
+        img_url = process.env.NEXT_PUBLIC_DEFAULT_OG_IMAGE;
+    }
     return (
         <Head>
             <title>{tabTitle}</title>
             <meta name="description" content={description} />
             <link rel="icon" href="/favicon.ico" />
+            {/* default og */}
             <meta property="og:type" content="website" />
             <meta property="og:image" content={img_url} />
             <meta property="og:image:width" content="1200" />
@@ -29,10 +33,13 @@ const MetaHead = ({
             />
             <meta property="og:title" content={title} />
             <meta property="og:description" content={description} />
-            <meta name="twitter:card" content="summary" />
+            {/* twitter Og */}
             <meta name="twitter:title" content={title} />
-            <meta name="twitter:description" content={description} />
             <meta name="twitter:image" content={img_url} />
+            <meta name="twitter:card" content="summary" />
+            <meta name="twitter:creator" content={'@duckdam trio'} />
+            <meta name="twitter:site" content={'@duckdam trio'} />/
+            <meta name="twitter:description" content={description} />
         </Head>
     );
 };

--- a/pages/result/[resultId].tsx
+++ b/pages/result/[resultId].tsx
@@ -60,8 +60,17 @@ const Result = () => {
                 <Button
                     onClick={() => {
                         if (duckdam) {
+                            /**
+                             * @typedef props
+                             * @type {object}
+                             * @property {string} imageURL - og:image 목적의 img_url
+                             * @property {string} resultId - firebase ObjectId
+                             * @description
+                             * TODO: img_url 디자인 작업 완료 후, 첫번째 카드 기준으로 image 생성하여 작업 필요함.
+                             * 현재 Default OG img 사용
+                             */
                             const props = {
-                                imageURL: duckdam.img_url,
+                                imageURL: process.env.NEXT_PUBLIC_OG,
                                 resultId: resultId,
                             };
                             shareWithKakao(props);


### PR DESCRIPTION
## 작업 내용
- 메타태그 og:image 매핑 오류 수정 262370f03e644dbd136e9127a444e208a2b60e70
  - 빈 스트링 변수에 default parameter 값이 할당되지 않는 오류 
- 트위터 관련 메타태그 추가

## 참고 자료 (option)
- 트위터 og태그
https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started