### PR TITLE
fix: 클립보드 복사 모바일에서도 정상작동되도록 수정

### DIFF
--- a/components/result/LinkCopyButton.tsx
+++ b/components/result/LinkCopyButton.tsx
@@ -49,6 +49,7 @@ const Result = styled.span`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    font-size: 14px;
     ::-webkit-scrollbar {
         width: 1rem;
     }
@@ -57,7 +58,8 @@ const Result = styled.span`
 const CopyButton = styled.button`
     background-color: ${({ theme }) => theme.color.brown};
     font-size: 16px;
-    width: 12%;
+    max-width: 12%;
+    width: 9%;
     height: 100%;
 `;
 

--- a/components/result/LinkCopyButton.tsx
+++ b/components/result/LinkCopyButton.tsx
@@ -1,19 +1,24 @@
 import styled from '@emotion/styled';
 import Image from 'next/image';
 import copyIcon from 'public/images/copy-icon.svg';
-import React from 'react';
+import React, { useRef } from 'react';
 
 type LinkCopyButtonProps = {
     children: React.ReactNode;
-    ref?: any;
-    onClick?: () => void;
 };
 
 const LinkCopyButton = (props: LinkCopyButtonProps) => {
+    const linkRef = useRef<HTMLSpanElement>(null);
+    const copyToClipboard = async () => {
+        const link = linkRef.current?.innerText as string;
+        await navigator.clipboard.writeText(link);
+        await alert('링크가 복사되었습니다!');
+    };
+
     return (
         <Container>
-            <Result ref={props.ref}>{props.children}</Result>
-            <CopyButton onClick={props.onClick}>
+            <Result ref={linkRef}>{props.children}</Result>
+            <CopyButton onClick={copyToClipboard}>
                 <StyledImage src={copyIcon} />
             </CopyButton>
         </Container>

--- a/pages/result/[resultId].tsx
+++ b/pages/result/[resultId].tsx
@@ -44,20 +44,7 @@ const Result = () => {
                         덕담은 비밀로 유지됩니다! 🤫
                     </Description>
                 </MessageBox>
-                <LinkCopyButton
-                    ref={urlArea}
-                    onClick={() => {
-                        const t = document.createElement('textarea');
-                        document.body.appendChild(t);
-                        t.value = resultURL;
-                        t.select();
-                        document.execCommand('copy');
-
-                        alert('링크가 복사되었습니다!');
-                    }}
-                >
-                    {resultURL}
-                </LinkCopyButton>
+                <LinkCopyButton>{resultURL}</LinkCopyButton>
             </Wrapper>
             <Bottom>
                 <Button
@@ -105,8 +92,6 @@ const Wrapper = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
-    /* justify-content: center;
-    align-items: center; */
 `;
 
 const ShareWrapper = styled.div`


### PR DESCRIPTION
## 작업 내용
- 모바일에서 링크 복사시 `textarea` 나오는 이슈 수정
![KakaoTalk_Photo_2022-09-10-04-10-06](https://user-images.githubusercontent.com/48716298/189426248-9780611a-3db7-415e-956f-54fc1910ff1f.jpeg)

## 관련 이슈

## 참고 자료 (option)
