### PR TITLE
[기능구현] 구글 애널리틱스 추가

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,6 +1,7 @@
 declare global {
     interface Window {
         Kakao: any;
+        gtag: (param1: string, param2: string, param3: object) => void;
     }
 }
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,46 @@
 import Layout from '@components/layout/Layout';
+import { useEffect } from 'react'
+import Script from 'next/script'
+import { useRouter } from 'next/router'
 import { Global, ThemeProvider } from '@emotion/react';
 import { global, theme } from '@styles/index';
 import type { AppProps } from 'next/app';
+import {GA_TRACKING_ID, pageview} from '@shared/utils/gtag';
 
 function MyApp({ Component, pageProps }: AppProps) {
+    const router = useRouter();
+    useEffect(() => {
+        const handleRouteChange = (url: string) => {
+            pageview(url);
+        }
+        router.events.on('routeChangeComplete', handleRouteChange);
+
+        return () => {
+            router.events.off('routeChangeComplete', handleRouteChange);
+        }
+    }, [router.events])
+
     return (
         <>
+            {/* Global Site Tag (gtag.js) - Google Analytics */}
+            <Script
+                strategy="afterInteractive"
+                src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+            />
+            <Script
+                id="gtag-init"
+                strategy="afterInteractive"
+                dangerouslySetInnerHTML={{
+                __html: `
+                    window.dataLayer = window.dataLayer || [];
+                    function gtag(){dataLayer.push(arguments);}
+                    gtag('js', new Date());
+                    gtag('config', '${GA_TRACKING_ID}', {
+                    page_path: window.location.pathname,
+                    });
+                `,
+                }}
+            />
             <ThemeProvider theme={theme}>
                 <Global styles={global} />
                 <Layout>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,24 +1,24 @@
 import Layout from '@components/layout/Layout';
-import { useEffect } from 'react'
-import Script from 'next/script'
-import { useRouter } from 'next/router'
 import { Global, ThemeProvider } from '@emotion/react';
+import { GA_TRACKING_ID, pageview } from '@shared/utils/gtag';
 import { global, theme } from '@styles/index';
 import type { AppProps } from 'next/app';
-import {GA_TRACKING_ID, pageview} from '@shared/utils/gtag';
+import { useRouter } from 'next/router';
+import Script from 'next/script';
+import { useEffect } from 'react';
 
 function MyApp({ Component, pageProps }: AppProps) {
     const router = useRouter();
     useEffect(() => {
         const handleRouteChange = (url: string) => {
             pageview(url);
-        }
+        };
         router.events.on('routeChangeComplete', handleRouteChange);
 
         return () => {
             router.events.off('routeChangeComplete', handleRouteChange);
-        }
-    }, [router.events])
+        };
+    }, [router.events]);
 
     return (
         <>
@@ -31,7 +31,7 @@ function MyApp({ Component, pageProps }: AppProps) {
                 id="gtag-init"
                 strategy="afterInteractive"
                 dangerouslySetInnerHTML={{
-                __html: `
+                    __html: `
                     window.dataLayer = window.dataLayer || [];
                     function gtag(){dataLayer.push(arguments);}
                     gtag('js', new Date());

--- a/shared/utils/gtag.ts
+++ b/shared/utils/gtag.ts
@@ -1,0 +1,17 @@
+export const GA_TRACKING_ID = process.env.NEXT_PUBLIC_GA_ID as string;
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/pages
+export const pageview = (url: string) => {
+  window.gtag('config', GA_TRACKING_ID, {
+    page_path: url,
+  })
+}
+
+// https://developers.google.com/analytics/devguides/collection/gtagjs/events
+export const event = ({ action, category, label, value }: any) => {
+  window.gtag('event', action, {
+    event_category: category,
+    event_label: label,
+    value: value,
+  })
+}


### PR DESCRIPTION
## 작업 내용
- [x] 구글 애널리틱스 추가

## 관련 이슈

### 1) 테스트 관련
테스트는 배포 이후에 확인해보겠습니다!

### 2) 카카오 스크립트 관련
> `next/script`를 이용해서 개발자들이 third-party 스크립트들의 로딩 우선순위를 설정할 수 있어 로딩 성능을 향상시킬 수 있다.
> `next/Head`를 _document.js에서만 사용할 수 있다면, `next/Script`는 _app.js에서만 위치시킬 수 있다.

[위와 같은 내용](https://nextjs.org/docs/basic-features/script)이 있어서 `_document.tsx`에 있는 **카카오 script**도 `_app.tsx`에 빼는 것이 좋을 것 같습니다!   
다른 분들의 의견이 궁금하여 아직 수정하진 않았으니 공유 부탁드려요~

## 참고 자료 (option)
[1. next.js + JavaScript + google analytics](https://velog.io/@yunsungyang-omc/Next.js-Google-Analystics-%EC%9D%B4%EC%8B%9D%ED%95%98%EA%B8%B0)
[2. next.js + TypeScript + google analytics](https://mnxmnz.github.io/nextjs/google-analytics/)
[3. next.js에서 작성한 구글 애널리틱스 코드 예제](https://github.com/vercel/next.js/tree/canary/examples/with-google-analytics)