### PR TITLE
[리팩토링, Fix] 코드 4차 리팩토링

### DIFF
--- a/pages/attitude/index.tsx
+++ b/pages/attitude/index.tsx
@@ -5,15 +5,20 @@ import { AttitudeRange, MessageBox, MessageItem } from '@/components/attitude';
 import { Button, Description, Title } from '@/components/common';
 import { Bottom } from '@/components/layout';
 import useAttitudeHooks from '@/shared/hooks/useAttitudeHooks';
+import useDuckdam from '@/shared/hooks/useDuckdam';
 import theme from '@/styles/theme';
 
 const Attitude = () => {
     const { message1, message2, askMessage, politeLevel, setPoliteRange } =
         useAttitudeHooks();
+
+    const { addNewDuckDam } = useDuckdam();
+
     const router = useRouter();
 
-    const handleAddNewDuckDam = () => {
-        router.push(`load/?politeLevel=${politeLevel}`);
+    const handleAddNewDuckDam = async () => {
+        const id = await addNewDuckDam(politeLevel);
+        router.push(`load/?id=${id}`);
     };
 
     return (

--- a/pages/load/index.tsx
+++ b/pages/load/index.tsx
@@ -1,22 +1,19 @@
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 import { LoadingLogo, Title } from '@/components/common';
-import useDuckdam from '@/shared/hooks/useDuckdam';
 
 const Load = () => {
-    const {
-        addNewDuckDam: addNewDuckDamHandler,
-        hasPoliteLevel,
-        getPoliteLevel,
-    } = useDuckdam();
+    const router = useRouter();
+    const { id } = router.query;
 
     useEffect(() => {
-        const politeLevel = getPoliteLevel();
+        const timer = setTimeout(() => router.push(`/result/${id}`), 3000);
 
-        if (hasPoliteLevel(politeLevel)) {
-            addNewDuckDamHandler(politeLevel);
-        }
-    }, [addNewDuckDamHandler, getPoliteLevel, hasPoliteLevel]);
+        return () => {
+            clearTimeout(timer);
+        };
+    }, [id, router]);
 
     return (
         <>

--- a/shared/hooks/useDuckdam.ts
+++ b/shared/hooks/useDuckdam.ts
@@ -1,12 +1,9 @@
 import axios from 'axios';
-import { useRouter } from 'next/router';
 
 import type { PoliteKey } from '@/shared/types/DuckDam';
 import { randomNewDuckDam } from '@/shared/utils/duckdamGenerator';
 
 const useDuckdam = () => {
-    const router = useRouter();
-
     const addNewDuckDam = async (politeLevel: PoliteKey) => {
         const newDuckDam = {
             ...randomNewDuckDam(politeLevel),
@@ -24,15 +21,7 @@ const useDuckdam = () => {
         }
     };
 
-    const hasPoliteLevel = (politeLevel: unknown): politeLevel is PoliteKey => {
-        return politeLevel !== undefined && typeof politeLevel === 'string';
-    };
-
-    const getPoliteLevel = () => {
-        return router.query.politeLevel;
-    };
-
-    return { addNewDuckDam, hasPoliteLevel, getPoliteLevel };
+    return { addNewDuckDam };
 };
 
 export default useDuckdam;

--- a/shared/hooks/useDuckdam.ts
+++ b/shared/hooks/useDuckdam.ts
@@ -20,7 +20,7 @@ const useDuckdam = () => {
         });
 
         if (status === 200) {
-            setTimeout(() => router.push(`/result/${data}`), 3000);
+            return data;
         }
     };
 


### PR DESCRIPTION
## 작업 내용

- [x] 랜덤 메시지 생성 시점 수정
  -  랜덤 덕담 생성 시점 예의도 결정 페이지로 이관 
  -  커스텀 덕담 추가 기능 감안하여 분리
- [x] 로딩 페이지에서 화면 이동 이후에도 라우팅 콜백 실행되는 버그
  - `setTimeout` 콜백 이벤트 발생 전, 라우팅 이동시 이벤트 제거

## 관련 이슈
Close #57 
